### PR TITLE
Backfill missing lab metadata (5 files)

### DIFF
--- a/Instructions/Labs/LAB_01_storage_test_training.md
+++ b/Instructions/Labs/LAB_01_storage_test_training.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Exercise 01: Provide storage for the IT department testing and training'
-    module: 'Guided Project - Azure Files and Azure Blobs'
+  title: 'Exercise 01: Provide storage for the IT department testing and training'
+  module: Guided Project - Azure Files and Azure Blobs
+  description: The IT department needs to prototype different storage scenarios and
+    to train new personnel. The content isn't important enough to back up and doesn't
+    need to be restored if the data is overwritten or removed. A simple configuration
+    that can be easily changed is desired.
+  duration: 20 minutes
+  level: 300
+  islab: true
 ---
 
 The IT department needs to prototype different storage scenarios and to train new personnel. The content isn't important enough to back up and doesn't need to be restored if the data is overwritten or removed. A simple configuration that can be easily changed is desired.

--- a/Instructions/Labs/LAB_02a_storage_public_website.md
+++ b/Instructions/Labs/LAB_02a_storage_public_website.md
@@ -1,8 +1,17 @@
 ---
 lab:
-    title: 'Exercise 02a: Provide storage for the public website'
-    module: 'Guided Project - Azure Files and Azure Blobs'
+  title: 'Exercise 02a: Provide storage for the public website'
+  module: Guided Project - Azure Files and Azure Blobs
+  description: The company website supplies product images, videos, marketing literature,
+    and customer success stories. Customers are located worldwide and demand is rapidly
+    expanding. The content is mission-critical and requires low latency load times.
+    It's important to keep track of the document versions and to quickly restore documents
+    if they're deleted.
+  duration: 20 minutes
+  level: 200
+  islab: true
 ---
+
 The company website supplies product images, videos, marketing literature, and customer success stories. Customers are located worldwide and demand is rapidly expanding. The content is mission-critical and requires low latency load times. It's important to keep track of the document versions and to quickly restore documents if they're deleted.
 
 ## Architecture diagram

--- a/Instructions/Labs/LAB_02b_storage_private_docs.md
+++ b/Instructions/Labs/LAB_02b_storage_private_docs.md
@@ -1,9 +1,15 @@
 ---
 lab:
-    title: 'Exercise 02b: Provide private storage for internal company documents'
-    module: 'Guided Project - Azure Files and Azure Blobs'
+  title: 'Exercise 02b: Provide private storage for internal company documents'
+  module: Guided Project - Azure Files and Azure Blobs
+  description: The company needs storage for their offices and departments. This content
+    is private to the company and shouldn't be shared without consent. This storage
+    requires high availability if there's a regional outage. The company wants to
+    use this storage to back up the public website.
+  duration: 20 minutes
+  level: 300
+  islab: true
 ---
-
 
 The company needs storage for their offices and departments. This content is private to the company and shouldn't be shared without consent. This storage requires high availability if there's a regional outage. The company wants to use this storage to back up the public website. 
 

--- a/Instructions/Labs/LAB_03_storage_file_shares.md
+++ b/Instructions/Labs/LAB_03_storage_file_shares.md
@@ -1,9 +1,16 @@
 ---
 lab:
-    title: 'Exercise 03: Provide shared file storage for the company offices'
-    module: 'Guided Project - Azure Files and Azure Blobs'
+  title: 'Exercise 03: Provide shared file storage for the company offices'
+  module: Guided Project - Azure Files and Azure Blobs
+  description: The company is geographically dispersed with offices in different locations.  These
+    offices need a way to share files and disseminate information. For example, the
+    Finance department needs to confirm cost information for auditing and compliance.
+    This file shares should be easy to access and load without delay. Some content
+    should only be accessed from selected corporate virtual networks.
+  duration: 30 minutes
+  level: 200
+  islab: true
 ---
-
 
 The company is geographically dispersed with offices in different locations.  These offices need a way to share files and disseminate information. For example, the Finance department needs to confirm cost information for auditing and compliance. This file shares should be easy to access and load without delay. Some content should only be accessed from selected corporate virtual networks.
 

--- a/Instructions/Labs/LAB_04_storage_web_app.md
+++ b/Instructions/Labs/LAB_04_storage_web_app.md
@@ -1,8 +1,16 @@
 ---
 lab:
-    title: 'Exercise 04: Provide storage for a new company app'
-    module: 'Guided Project - Azure Files and Azure Blobs'
+  title: 'Exercise 04: Provide storage for a new company app'
+  module: Guided Project - Azure Files and Azure Blobs
+  description: The company is designing and developing a new app. Developers need
+    to ensure the storage is only accessed using keys and managed identities. The
+    developers would like to use role-based access control. To help with testing,
+    protected immutable storage is needed.
+  duration: 30 minutes
+  level: 500
+  islab: true
 ---
+
 The company is designing and developing a new app. Developers need to ensure the storage is only accessed using keys and managed identities. The developers would like to use role-based access control. To help with testing, protected immutable storage is needed. 
 
 ## Architecture diagram


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 5

- `Instructions/Labs/LAB_01_storage_test_training.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_02a_storage_public_website.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_02b_storage_private_docs.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_03_storage_file_shares.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_04_storage_web_app.md` (description,duration,level,islab)
